### PR TITLE
Add inbound call test

### DIFF
--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -1,7 +1,17 @@
 const request = require('supertest');
 
+// Mock firebase-admin to avoid needing real credentials during tests
+jest.mock('firebase-admin', () => ({
+  initializeApp: jest.fn(),
+  messaging: () => ({
+    send: jest.fn(),
+  }),
+  credential: { cert: jest.fn() },
+}));
+
 // Set env vars before requiring the app
 process.env.API_KEY = 'test-key';
+process.env.TWILIO_PHONE_NUMBER = '+15558675310';
 const app = require('../server');
 
 describe('API routes', () => {
@@ -14,9 +24,22 @@ describe('API routes', () => {
   test('POST /api/voice-inbound responds with TwiML', async () => {
     const res = await request(app)
       .post('/api/voice-inbound')
-      .type('form')
       .send({ CallStatus: 'ringing' });
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/xml/);
+  });
+
+  test('POST /api/voice-inbound with call data returns dial TwiML', async () => {
+    const res = await request(app)
+      .post('/api/voice-inbound')
+      .send({
+        CallSid: 'CA1234567890',
+        From: '+15005550006',
+        To: process.env.TWILIO_PHONE_NUMBER,
+        CallStatus: 'ringing',
+      });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/xml/);
+    expect(res.text).toMatch(/<Dial>/);
   });
 });


### PR DESCRIPTION
## Summary
- mock firebase-admin in tests
- ensure Twilio phone number env var is set for testing
- add test for `/api/voice-inbound` with call data

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684a3583b87c8331a95f2ceffc154ae7