### PR TITLE
Fix Twilio Android initialization

### DIFF
--- a/src/TwilioMobileApp/android/app/src/main/java/com/twiliomobileapp/MainActivity.java
+++ b/src/TwilioMobileApp/android/app/src/main/java/com/twiliomobileapp/MainActivity.java
@@ -1,0 +1,46 @@
+package com.twiliomobileapp;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.facebook.react.ReactActivity;
+import com.twiliovoicereactnative.VoiceActivityProxy;
+
+public class MainActivity extends ReactActivity {
+  private final VoiceActivityProxy activityProxy = new VoiceActivityProxy(this);
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    activityProxy.onCreate(savedInstanceState);
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    activityProxy.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    activityProxy.onStop();
+    super.onStop();
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    activityProxy.onNewIntent(intent);
+    super.onNewIntent(intent);
+  }
+
+  @Override
+  protected void onDestroy() {
+    activityProxy.onDestroy();
+    super.onDestroy();
+  }
+
+  @Override
+  protected String getMainComponentName() {
+    return "main";
+  }
+}

--- a/src/TwilioMobileApp/android/app/src/main/java/com/twiliomobileapp/MainApplication.java
+++ b/src/TwilioMobileApp/android/app/src/main/java/com/twiliomobileapp/MainApplication.java
@@ -1,0 +1,51 @@
+package com.twiliomobileapp;
+
+import android.app.Application;
+
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactNativeHost;
+import com.facebook.react.ReactPackage;
+import com.facebook.react.PackageList;
+import com.twiliovoicereactnative.VoiceApplicationProxy;
+
+import java.util.List;
+
+public class MainApplication extends Application implements ReactApplication {
+  private final VoiceApplicationProxy voiceApplicationProxy =
+      new VoiceApplicationProxy(this);
+
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+    @Override
+    public boolean getUseDeveloperSupport() {
+      return BuildConfig.DEBUG;
+    }
+
+    @Override
+    protected List<ReactPackage> getPackages() {
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      return packages;
+    }
+
+    @Override
+    protected String getJSMainModuleName() {
+      return "index";
+    }
+  };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    voiceApplicationProxy.onCreate();
+  }
+
+  @Override
+  public void onTerminate() {
+    voiceApplicationProxy.onTerminate();
+    super.onTerminate();
+  }
+}


### PR DESCRIPTION
## Summary
- add Android `MainActivity` and `MainApplication` with Twilio proxies

## Testing
- `npm test --prefix backend` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684cd0629cdc833183d1686d3d95e329